### PR TITLE
Bugfix: Assign correct enum types

### DIFF
--- a/schemas/v1/bo/Marktlokation.schema.json
+++ b/schemas/v1/bo/Marktlokation.schema.json
@@ -21,7 +21,7 @@
       "description": "Identifikationsnummer einer Marktlokation, an der Energie entweder\nverbraucht, oder erzeugt wird"
     },
     "sparte": {
-      "type": "string",
+      "$ref": "../enum/Sparte.schema.json",
       "description": "Strom oder Gas."
     },
     "energierichtung": {

--- a/schemas/v1/com/Lastprofil.schema.json
+++ b/schemas/v1/com/Lastprofil.schema.json
@@ -23,7 +23,7 @@
       "description": "Kennzeichen Einspeisung"
     },
     "herausgeber": {
-      "type": "string",
+      "$ref": "../enum/Herausgeber.schema.json",
       "description": "Herausgeber des Lastprofils"
     },
     "tagesparameter": {


### PR DESCRIPTION
I might have found 2 inconsistencies where an attribute type could be scpecified to an existing enum instead of using a primitive type:
* com.Lastprofil.herausgeber -> enum.Herausgeber
* bo.Marktlokation.sparte -> enum.Sparte