### PR TITLE
[BUGFIX][MACO-13069@CU] Fix typo in Angebotsposition: positionsbezeichung -> positionsbezeichnung

### DIFF
--- a/schemas/v1/com/Angebotsposition.schema.json
+++ b/schemas/v1/com/Angebotsposition.schema.json
@@ -4,7 +4,7 @@
   "title": "Angebotsposition",
   "type": "object",
   "properties": {
-    "positionsbezeichung": {
+    "positionsbezeichnung": {
       "type": "string",
       "description": "Bezeichnung der Position"
     },

--- a/translation/v1/DE_to_EN.yaml
+++ b/translation/v1/DE_to_EN.yaml
@@ -682,7 +682,7 @@ object_property_names:
   positionen: positions  # bo/Avis, com/Angebotsteil, com/Avisposition
   positionsMenge: positionQuantity  # com/Rechnungsposition
   positionsbetrag: positionAmount  # com/Angebotsposition, com/AuftragPosition
-  positionsbezeichung: positionDesignation  # com/Angebotsposition
+  positionsbezeichnung: positionDesignation  # com/Angebotsposition
   positionsdaten: positionData  # bo/Angebot, bo/Auftrag, bo/Statusmitteilung
   positionsmenge: itemQuantity  # com/Angebotsposition
   positionsnummer: positionNumber  # com/AuftragPosition, com/Preisposition, com/Rechnungsposition, com/Rueckmeldungsposition, com/StatusmitteilungPosition


### PR DESCRIPTION
Task: https://conuti.atlassian.net/browse/MACO-13069

## Summary

The BO4E property `Com.Angebotsposition.positionsbezeichung` was missing the `n` before `...ung`. This PR corrects the spelling in the schema source of truth and updates the DE→EN translation key so downstream translation generation emits the corrected identifier.

## Changes

- `schemas/v1/com/Angebotsposition.schema.json` — property renamed `positionsbezeichung` → `positionsbezeichnung`
- `translation/v1/DE_to_EN.yaml` — translation key renamed accordingly (English value `positionDesignation` unchanged)

Auto-generated artifacts under `docs/` (openapi.yaml, openapi-model/, schemas/v1/*.md, examples/) are intentionally not touched here — `bo4e-generator` regenerates them on the next sync commit.

## Migration note for consumers

This is a **breaking property rename** in `Com.Angebotsposition`. Consumers serializing/deserializing this object must switch from `positionsbezeichung` to `positionsbezeichnung` after the new tag is released. Generated docs (`docs/openapi*.yaml`, `docs/schemas/v1/angebotsposition*.md`, example JSON files) will follow automatically once the generator re-runs on master.

## Follow-up (separate repos, sequential)

1. `conuti/bo4e-php` — rename property in `src/v1/Com/Angebotsposition.php`, tag new release.
2. `maco-templater-app` — bump `bo4e-schema` + `bo4e-php` deps, then in `src/EdiMessage/v{202504,202510,202604}/v1/Quotes/SegmentBuilder/AngebotspositionSegmentBuilder.php`:
   - PHP property access `$this->position?->positionsbezeichung` → `…->positionsbezeichnung`
   - `addMissingDataPath('…positionsbezeichung')` → `…positionsbezeichnung`
   - `LINFactory::create(d1082: $this->position->positionsbezeichung, …)` → `…->positionsbezeichnung`
   - `#[ObjectPath(path: 'positionsbezeichung')]` (downshifted in MACO-13068 Cluster 11) → `'positionsbezeichnung'`

## Verification

After 3a (this PR) + 3b + 3c are landed:
`php bin/console create-openapi-spec --filter-scope=QUOTES` must show no drift on `positionsbezeichung`/`positionsbezeichnung` paths in the templater repo (per MACO-13068 Cluster 11).

## Sequencing

Step 2 of MACO-13069 (templater downshift to typo form via MACO-13068 Cluster 11) should be merged **before** tagging this schema fix, so the templater is not transiently inconsistent in the other direction.