### PR TITLE
[FEATURE][MACO-13284@CU] BO4E-Erweiterungen aus Mapping 202610 IFTSTA

### DIFF
--- a/schemas/v1/com/AnsichtSender.schema.json
+++ b/schemas/v1/com/AnsichtSender.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/conuti-gmbh/bo4e-schema/master/schemas/v1/com/AnsichtSender.schema.json",
+  "title": "AnsichtSender",
+  "type": "object",
+  "properties": {
+    "verwendungAb": {
+      "type": "string",
+      "format": "date-time",
+      "description": "verwendungAb"
+    },
+    "verwendungBis": {
+      "type": "string",
+      "format": "date-time",
+      "description": "verwendungBis"
+    },
+    "leistungsperiode": {
+      "type": "string",
+      "description": "leistungsperiode"
+    },
+    "menge": {
+      "$ref": "../com/Menge.schema.json"
+    },
+    "tarifstufe": {
+      "$ref": "../enum/Tarifstufe.schema.json"
+    }
+  }
+}

--- a/schemas/v1/com/StatusmitteilungPosition.schema.json
+++ b/schemas/v1/com/StatusmitteilungPosition.schema.json
@@ -78,6 +78,90 @@
         "$ref": "../enum/Auftragsstatus.schema.json"
       },
       "description": "auftragsStatusListe"
+    },
+    "lokationsTyp": {
+      "$ref": "../enum/Lokationstyp.schema.json"
+    },
+    "statusObjekt": {
+      "$ref": "../enum/Statusobjekt.schema.json"
+    },
+    "antwortstatusCodeliste": {
+      "type": "string",
+      "description": "antwortstatusCodeliste"
+    },
+    "vorgangsreferenznummer": {
+      "type": "string",
+      "description": "vorgangsreferenznummer"
+    },
+    "mitteilungsnummer": {
+      "type": "string",
+      "description": "mitteilungsnummer"
+    },
+    "anfragereferenznummer": {
+      "type": "string",
+      "description": "anfragereferenznummer"
+    },
+    "fertigstellungsdatum": {
+      "type": "string",
+      "format": "date-time",
+      "description": "fertigstellungsdatum"
+    },
+    "lieferdatum": {
+      "type": "string",
+      "description": "lieferdatum"
+    },
+    "sendungsposition": {
+      "type": "integer",
+      "description": "sendungsposition"
+    },
+    "gueltigAb": {
+      "type": "string",
+      "format": "date-time",
+      "description": "gueltigAb"
+    },
+    "referenzMalo": {
+      "type": "string",
+      "description": "referenzMalo"
+    },
+    "referenzPreisschluesselstamm": {
+      "type": "string",
+      "description": "referenzPreisschluesselstamm"
+    },
+    "referenzArtikelID": {
+      "type": "string",
+      "description": "referenzArtikelID"
+    },
+    "startdatum": {
+      "type": "string",
+      "format": "date-time",
+      "description": "startdatum"
+    },
+    "angebotsnummer": {
+      "type": "string",
+      "description": "angebotsnummer"
+    },
+    "anfrageReferenz": {
+      "type": "string",
+      "description": "anfrageReferenz"
+    },
+    "vertragsende": {
+      "type": "string",
+      "format": "date-time",
+      "description": "vertragsende"
+    },
+    "ansichtSender": {
+      "type": ["array", "null"],
+      "items": {
+        "$ref": "../com/AnsichtSender.schema.json"
+      },
+      "description": "ansichtSender"
+    },
+    "gueltigkeitsZeitspanne": {
+      "type": "string",
+      "description": "gueltigkeitsZeitspanne"
+    },
+    "privilegierteEnergiemenge": {
+      "$ref": "../com/ZeitintervallMenge.schema.json"
     }
   }
 }

--- a/schemas/v1/com/ZeitintervallMenge.schema.json
+++ b/schemas/v1/com/ZeitintervallMenge.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/conuti-gmbh/bo4e-schema/master/schemas/v1/com/ZeitintervallMenge.schema.json",
+  "title": "ZeitintervallMenge",
+  "type": "object",
+  "properties": {
+    "verwendungAb": {
+      "type": "string",
+      "format": "date-time",
+      "description": "verwendungAb"
+    },
+    "verwendungBis": {
+      "type": "string",
+      "format": "date-time",
+      "description": "verwendungBis"
+    },
+    "menge": {
+      "$ref": "../com/Menge.schema.json"
+    }
+  }
+}

--- a/translation/v1/DE_to_EN.yaml
+++ b/translation/v1/DE_to_EN.yaml
@@ -331,6 +331,7 @@ object_property_names:
   angebotsnummer: offerNumber  # bo/Angebot
   angebotsstatus: offerStatus  # com/Angebotsvariante
   anrede: salutation  # bo/Geschaeftspartner, bo/Marktteilnehmer
+  ansichtSender: senderView  # com/StatusmitteilungPosition
   ansprechpartner: contactPerson  # bo/Marktteilnehmer
   anteil: share  # com/Energiemix
   anteilProzent: sharePercent  # com/Energieherkunft
@@ -712,6 +713,7 @@ object_property_names:
   preisstatus: priceStatus  # bo/Preisblatt
   priorisierung: prioritization  # com/Produktpaket
   prioritaet: priority  # bo/Bilanzkreis
+  privilegierteEnergiemenge: privilegedEnergyQuantity  # com/StatusmitteilungPosition
   produkt: product  # com/Produktpaket
   produktCode: productCode  # com/Produkt
   produktdatenRelevanteRolle: productDataRelevantRole  # bo/Marktlokation, bo/Netzlokation, bo/SteuerbareRessource
@@ -2746,6 +2748,7 @@ object_names:
   Angebotsposition: OfferPosition  # com
   Angebotsteil: OfferPart  # com
   Angebotsvariante: OfferVariant  # com
+  AnsichtSender: SenderView  # com
   AntwortStatusZeitraum: ResponseStatusPeriod  # com
   AuftragPosition: OrderPosition  # com
   Aussteller: Issuer  # com
@@ -2813,6 +2816,7 @@ object_names:
   Zaehlwerk: MeterRegister  # com
   Zaehlzeit: MeteringTime  # com
   Zaehlzeitregister: MeteringTimeRegister  # com
+  ZeitintervallMenge: TimeIntervalQuantity  # com
   Zeitraum: TimePeriod  # com
   ZertifikatsAussteller: CertificateIssuer  # com
   ZertifikatsNutzer: CertificateUser  # com


### PR DESCRIPTION
Task: https://conuti.atlassian.net/browse/MACO-13284

`StatusmitteilungPosition` (COM) um 20 Properties erweitert:
lokationsTyp, statusObjekt, antwortstatusCodeliste, vorgangsreferenznummer, mitteilungsnummer, anfragereferenznummer, fertigstellungsdatum, lieferdatum (reiner String, CCYYMMDD/303), sendungsposition, gueltigAb, referenzMalo, referenzPreisschluesselstamm, referenzArtikelID, startdatum, angebotsnummer, anfrageReferenz, vertragsende, ansichtSender[], gueltigkeitsZeitspanne, privilegierteEnergiemenge.

Neue COMs:
- `AnsichtSender` (verwendungAb, verwendungBis, leistungsperiode, menge→Menge, tarifstufe→Tarifstufe)
- `ZeitintervallMenge` (verwendungAb, verwendungBis, menge→Menge)

Übersetzungen in `translation/v1/DE_to_EN.yaml` ergänzt (4 neue Identifier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)